### PR TITLE
Fix for empty search filter and None return

### DIFF
--- a/lib/ansible/plugins/lookup/ldap.py
+++ b/lib/ansible/plugins/lookup/ldap.py
@@ -169,7 +169,7 @@ class LdapEntries(object):
         result = False
         if self.dn:
             result = self.connection.search(
-                self.dn, '', search_scope=ldap3.SUBTREE, attributes=ldap3.ALL_ATTRIBUTES)
+                self.dn, '(objectClass=*)', search_scope=ldap3.SUBTREE, attributes=ldap3.ALL_ATTRIBUTES)
         else:
             result = self.connection.search(
                 self.search_base, self.search_filter, search_scope=ldap3.SUBTREE, attributes=ldap3.ALL_ATTRIBUTES)
@@ -177,7 +177,7 @@ class LdapEntries(object):
         if result:
             return self.connection.response
 
-        return None
+        return []
 
     def close(self):
         if self.connection:


### PR DESCRIPTION
Return an empty array if nothing was found
Add ObjectClass=* filter to dn search

##### SUMMARY
if the search doesn't return any entries there is a NoneType return that causes an exception:
```
Fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'ldap'. Error was a <class 'TypeError'>, original message: 'NoneType' object is not iterable"} 
```
Searching for a dn with an empty string fails with:
```
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'ldap'. Error was a <class 'ldap3.core.exceptions.LDAPInvalidFilterError'>, original message: invalid filter"}                                                                                                                                        
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/ldap.py

##### ANSIBLE VERSION
```
ansible 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/gfdsa/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.1 (default, Nov  5 2018, 14:07:04) [GCC 8.2.1 20181011 (Red Hat 8.2.1-4)]
```


##### ADDITIONAL INFORMATION
All the LDAPing is against an AD